### PR TITLE
fix: Eliminar archivo .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-DB_USERNAME=dev_user
-DB_PASSWORD=dev_password


### PR DESCRIPTION
Se eliminó el archivo de variables de entorno .env para que no se suba al repositorio de GitHub y se mantenga en local solamente.