### PR TITLE
Implementar CRUD simple final

### DIFF
--- a/backend/src/main/java/com/ceiba/fashtoll/controller/BrandController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/controller/BrandController.java
@@ -1,6 +1,6 @@
 package com.ceiba.fashtoll.controller;
 
-import com.ceiba.fashtoll.entity.Brand;
+import com.ceiba.fashtoll.dto.BrandDTO;
 import com.ceiba.fashtoll.service.BrandService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -21,24 +21,24 @@ public class BrandController {
     }
 
     @GetMapping
-    public List<Brand> getAllBrands() {
+    public List<BrandDTO> getAllBrands() {
         return brandService.getAllBrands();
     }
 
     @GetMapping("/{id}")
-    public Brand getBrandById(@PathVariable Long id) {
+    public BrandDTO getBrandById(@PathVariable Long id) {
         return brandService.getBrandById(id);
     }
 
     @PostMapping
-    public ResponseEntity<Brand> createBrand(@RequestBody Brand brand) {
-        Brand newBrand = brandService.createBrand(brand);
+    public ResponseEntity<BrandDTO> createBrand(@RequestBody BrandDTO brandDTO) {
+        BrandDTO newBrand = brandService.createBrand(brandDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(newBrand);
     }
 
     @PutMapping("/{id}")
-    public Brand updateBrand(@PathVariable Long id, @RequestBody Brand updatedBrand) {
-        return brandService.updateBrand(id, updatedBrand);
+    public BrandDTO updateBrand(@PathVariable Long id, @RequestBody BrandDTO updatedBrandDTO) {
+        return brandService.updateBrand(id, updatedBrandDTO);
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/ceiba/fashtoll/controller/ClientController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/controller/ClientController.java
@@ -1,6 +1,6 @@
 package com.ceiba.fashtoll.controller;
 
-import com.ceiba.fashtoll.entity.Client;
+import com.ceiba.fashtoll.dto.ClientDTO;
 import com.ceiba.fashtoll.service.ClientService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -21,24 +21,24 @@ public class ClientController {
     }
 
     @GetMapping
-    public List<Client> getAllClients() {
+    public List<ClientDTO> getAllClients() {
         return clientService.getAllClients();
     }
 
     @GetMapping("/{id}")
-    public Client getClientById(@PathVariable Long id) {
+    public ClientDTO getClientById(@PathVariable Long id) {
         return clientService.getClientById(id);
     }
 
     @PostMapping
-    public ResponseEntity<Client> createClient(@RequestBody Client client) {
-        Client newClient = clientService.createClient(client);
+    public ResponseEntity<ClientDTO> createClient(@RequestBody ClientDTO clientDTO) {
+        ClientDTO newClient = clientService.createClient(clientDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(newClient);
     }
 
     @PutMapping("/{id}")
-    public Client updateClient(@PathVariable Long id, @RequestBody Client updatedClient) {
-        return clientService.updateClient(id, updatedClient);
+    public ClientDTO updateClient(@PathVariable Long id, @RequestBody ClientDTO updatedClientDTO) {
+        return clientService.updateClient(id, updatedClientDTO);
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/ceiba/fashtoll/controller/ProductController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/controller/ProductController.java
@@ -1,4 +1,49 @@
 package com.ceiba.fashtoll.controller;
 
+import com.ceiba.fashtoll.dto.ProductDTO;
+import com.ceiba.fashtoll.service.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/products")
 public class ProductController {
+
+    private final ProductService productService;
+
+    @Autowired
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
+
+    @GetMapping
+    public List<ProductDTO> getAllProducts() {
+        return productService.getAllProducts();
+    }
+
+    @GetMapping("/{id}")
+    public ProductDTO getProductById(@PathVariable Long id) {
+        return productService.getProductById(id);
+    }
+
+    @PostMapping
+    public ResponseEntity<ProductDTO> createProduct(@RequestBody ProductDTO productDTO) {
+        ProductDTO newProduct = productService.createProduct(productDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(newProduct);
+    }
+
+    @PutMapping("/{id}")
+    public ProductDTO updateProduct(@PathVariable Long id, @RequestBody ProductDTO updatedProductDTO) {
+        return productService.updateProduct(id, updatedProductDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {
+        productService.deleteProduct(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/ceiba/fashtoll/controller/ProductTypeController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/controller/ProductTypeController.java
@@ -1,0 +1,49 @@
+package com.ceiba.fashtoll.controller;
+
+import com.ceiba.fashtoll.dto.ProductTypeDTO;
+import com.ceiba.fashtoll.service.ProductTypeService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/product-types")
+public class ProductTypeController {
+
+    private final ProductTypeService productTypeService;
+
+    @Autowired
+    public ProductTypeController(ProductTypeService productTypeService) {
+        this.productTypeService = productTypeService;
+    }
+
+    @GetMapping
+    public List<ProductTypeDTO> getAllProductTypes() {
+        return productTypeService.getAllProductTypes();
+    }
+
+    @GetMapping("/{id}")
+    public ProductTypeDTO getProductTypeById(@PathVariable Long id) {
+        return productTypeService.getProductTypeById(id);
+    }
+
+    @PostMapping
+    public ResponseEntity<ProductTypeDTO> createProductType(@RequestBody ProductTypeDTO productTypeDTO) {
+        ProductTypeDTO newProductType = productTypeService.createProductType(productTypeDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(newProductType);
+    }
+
+    @PutMapping("/{id}")
+    public ProductTypeDTO updateProductType(@PathVariable Long id, @RequestBody ProductTypeDTO updatedProductTypeDTO) {
+        return productTypeService.updateProductType(id, updatedProductTypeDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteProductType(@PathVariable Long id) {
+        productTypeService.deleteProductType(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/controller/UserController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/controller/UserController.java
@@ -1,0 +1,49 @@
+package com.ceiba.fashtoll.controller;
+
+import com.ceiba.fashtoll.dto.UserDTO;
+import com.ceiba.fashtoll.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public List<UserDTO> getAllUsers() {
+        return userService.getAllUsers();
+    }
+
+    @GetMapping("/{id}")
+    public UserDTO getUserById(@PathVariable Long id) {
+        return userService.getUserById(id);
+    }
+
+    @PostMapping
+    public ResponseEntity<UserDTO> createUser(@RequestBody UserDTO userDTO) {
+        UserDTO newUser = userService.createUser(userDTO);
+        return ResponseEntity.status(HttpStatus.CREATED).body(newUser);
+    }
+
+    @PutMapping("/{id}")
+    public UserDTO updateUser(@PathVariable Long id, @RequestBody UserDTO updatedUserDTO) {
+        return userService.updateUser(id, updatedUserDTO);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/dto/BrandDTO.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/dto/BrandDTO.java
@@ -1,0 +1,19 @@
+package com.ceiba.fashtoll.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrandDTO {
+    private Long id;
+    private String name;
+    private String pictureUrl;
+    private String linkOfficial;
+    private Integer followers;
+    private Double rating;
+    private Boolean isVerified;
+    private Long userId;
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/dto/ClientDTO.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/dto/ClientDTO.java
@@ -1,0 +1,14 @@
+package com.ceiba.fashtoll.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClientDTO {
+    private Long id;
+    private String name;
+    private Long userId;
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/dto/ProductDTO.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/dto/ProductDTO.java
@@ -1,0 +1,30 @@
+package com.ceiba.fashtoll.dto;
+
+import com.ceiba.fashtoll.enums.Color;
+import com.ceiba.fashtoll.enums.Gender;
+import com.ceiba.fashtoll.enums.GeneralFit;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductDTO {
+    private Long id;
+    private String name;
+    private String description;
+    private BigDecimal price;
+    private GeneralFit generalFit;
+    private Gender gender;
+    private Color color;
+    private Boolean available;
+    private Double rating;
+    private String linkProduct;
+    private LocalDateTime createdAt;
+    private Long brandId;
+    private Long productTypeId;
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/dto/ProductTypeDTO.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/dto/ProductTypeDTO.java
@@ -1,0 +1,15 @@
+package com.ceiba.fashtoll.dto;
+
+import com.ceiba.fashtoll.enums.Category;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductTypeDTO {
+    private Long id;
+    private String name;
+    private Category category;
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/dto/UserDTO.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/dto/UserDTO.java
@@ -1,0 +1,20 @@
+package com.ceiba.fashtoll.dto;
+
+import com.ceiba.fashtoll.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserDTO {
+    private Long id;
+    private String email;
+    private String password;
+    private Role role;
+    private LocalDateTime createdAt;
+    private Boolean isActive;
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/entity/Brand.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/entity/Brand.java
@@ -1,5 +1,6 @@
 package com.ceiba.fashtoll.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
@@ -16,20 +17,16 @@ import java.util.List;
 @AllArgsConstructor
 public class Brand {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long id; // Se asignará el mismo id que el de User
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @NotBlank(message = "El nombre de la marca es obligatorio")
     @Size(max = 100)
     private String name;
-
-    @NotBlank(message = "El email es obligatorio")
-    @Email(message = "Debe ser un email válido")
-    @Column(unique = true, length = 150)
-    private String email;
-
-    @NotBlank(message = "La contraseña es obligatoria")
-    private String password; // hash de BCrypt
 
     @Column(name = "picture_url", length = 500)
     private String pictureUrl;
@@ -46,6 +43,7 @@ public class Brand {
     private Boolean isVerified = false;
 
     @OneToMany(mappedBy = "brand", cascade = CascadeType.ALL)
+    @JsonIgnore // Para que jackon no serialice los productos de la marca
     private List<Product> products = new ArrayList<>();
 
     /* Cuando exista Tag

--- a/backend/src/main/java/com/ceiba/fashtoll/entity/Client.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/entity/Client.java
@@ -15,20 +15,16 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Client {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long id; // Se asignará el mismo id que el de User
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;
 
     @NotBlank(message = "El nombre es obligatorio")
     @Size(max = 100)
     private String name;
-
-    @NotBlank(message = "El email es obligatorio")
-    @Email(message = "Debe ser un email válido")
-    @Column(unique = true, length = 150)
-    private String email;
-
-    @NotBlank(message = "La contraseña es obligatoria")
-    private String password; // hash de BCrypt
 
     /* Cuando exista Wishlist
     @OneToMany(mappedBy = "client", cascade = CascadeType.ALL)

--- a/backend/src/main/java/com/ceiba/fashtoll/entity/Product.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/entity/Product.java
@@ -3,11 +3,13 @@ package com.ceiba.fashtoll.entity;
 import com.ceiba.fashtoll.enums.Color;
 import com.ceiba.fashtoll.enums.Gender;
 import com.ceiba.fashtoll.enums.GeneralFit;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -24,6 +26,7 @@ public class Product {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "brand_id", nullable = false)
+    @JsonIgnore // para que jackson no serialice el objeto marca
     private Brand brand;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -60,7 +63,8 @@ public class Product {
     private String linkProduct;
 
     @Column(name = "created_at")
-    private LocalDateTime createdAt = LocalDateTime.now();
+    @CreationTimestamp
+    private LocalDateTime createdAt;
 
     /* Cuando exista ProductImage y Tag
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)

--- a/backend/src/main/java/com/ceiba/fashtoll/entity/User.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/entity/User.java
@@ -1,0 +1,69 @@
+package com.ceiba.fashtoll.entity;
+
+import com.ceiba.fashtoll.enums.Role;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank(message = "El email es obligatorio")
+    @Email(message = "Debe ser un email válido")
+    @Column(unique = true, length = 150)
+    private String email;
+
+    @NotBlank(message = "La contraseña es obligatoria")
+    private String password; // hash de BCrypt
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Column(name = "created_at")
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @Column(name = "is_active")
+    private Boolean isActive = true;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private Client client;
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private Brand brand;
+
+    /* Cuando se implemente UserDetails de Spring Security
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public String getUsername() { return email; }
+
+    @Override
+    public boolean isAccountNonExpired()  { return true; }
+
+    @Override
+    public boolean isAccountNonLocked()   { return true; }
+
+    @Override
+    public boolean isCredentialsNonExpired() { return true; }
+
+    @Override
+    public boolean isEnabled() { return isActive; }
+     */
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/enums/Role.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/enums/Role.java
@@ -1,0 +1,7 @@
+package com.ceiba.fashtoll.enums;
+
+public enum Role {
+    CLIENT,
+    BRAND,
+    ADMIN
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/mapper/BrandMapper.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/mapper/BrandMapper.java
@@ -1,0 +1,36 @@
+package com.ceiba.fashtoll.mapper;
+
+import com.ceiba.fashtoll.dto.BrandDTO;
+import com.ceiba.fashtoll.entity.Brand;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BrandMapper {
+
+    public BrandDTO toDTO(Brand brand) {
+        if (brand == null) return null;
+        BrandDTO dto = new BrandDTO();
+        dto.setId(brand.getId());
+        dto.setName(brand.getName());
+        dto.setPictureUrl(brand.getPictureUrl());
+        dto.setLinkOfficial(brand.getLinkOfficial());
+        dto.setFollowers(brand.getFollowers());
+        dto.setRating(brand.getRating());
+        dto.setIsVerified(brand.getIsVerified());
+        dto.setUserId(brand.getUser() != null ? brand.getUser().getId() : null);
+        return dto;
+    }
+
+    public Brand toEntity(BrandDTO dto) {
+        if (dto == null) return null;
+        Brand brand = new Brand();
+        brand.setId(dto.getId());
+        brand.setName(dto.getName());
+        brand.setPictureUrl(dto.getPictureUrl());
+        brand.setLinkOfficial(dto.getLinkOfficial());
+        brand.setFollowers(dto.getFollowers());
+        brand.setRating(dto.getRating());
+        brand.setIsVerified(dto.getIsVerified());
+        return brand;
+    }
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/mapper/ClientMapper.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/mapper/ClientMapper.java
@@ -1,0 +1,26 @@
+package com.ceiba.fashtoll.mapper;
+
+import com.ceiba.fashtoll.dto.ClientDTO;
+import com.ceiba.fashtoll.entity.Client;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ClientMapper {
+
+    public ClientDTO toDTO(Client client) {
+        if (client == null) return null;
+        ClientDTO dto = new ClientDTO();
+        dto.setId(client.getId());
+        dto.setName(client.getName());
+        dto.setUserId(client.getUser() != null ? client.getUser().getId() : null);
+        return dto;
+    }
+
+    public Client toEntity(ClientDTO dto) {
+        if (dto == null) return null;
+        Client client = new Client();
+        client.setId(dto.getId());
+        client.setName(dto.getName());
+        return client;
+    }
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/mapper/ProductMapper.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/mapper/ProductMapper.java
@@ -1,0 +1,45 @@
+package com.ceiba.fashtoll.mapper;
+
+import com.ceiba.fashtoll.dto.ProductDTO;
+import com.ceiba.fashtoll.entity.Product;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductMapper {
+
+    public ProductDTO toDTO(Product product) {
+        if (product == null) return null;
+        ProductDTO dto = new ProductDTO();
+        dto.setId(product.getId());
+        dto.setName(product.getName());
+        dto.setDescription(product.getDescription());
+        dto.setPrice(product.getPrice());
+        dto.setGeneralFit(product.getGeneralFit());
+        dto.setGender(product.getGender());
+        dto.setColor(product.getColor());
+        dto.setAvailable(product.getAvailable());
+        dto.setRating(product.getRating());
+        dto.setLinkProduct(product.getLinkProduct());
+        dto.setCreatedAt(product.getCreatedAt());
+        dto.setBrandId(product.getBrand() != null ? product.getBrand().getId() : null);
+        dto.setProductTypeId(product.getProductType() != null ? product.getProductType().getId() : null);
+        return dto;
+    }
+
+    public Product toEntity(ProductDTO dto) {
+        if (dto == null) return null;
+        Product product = new Product();
+        product.setId(dto.getId());
+        product.setName(dto.getName());
+        product.setDescription(dto.getDescription());
+        product.setPrice(dto.getPrice());
+        product.setGeneralFit(dto.getGeneralFit());
+        product.setGender(dto.getGender());
+        product.setColor(dto.getColor());
+        product.setAvailable(dto.getAvailable());
+        product.setRating(dto.getRating());
+        product.setLinkProduct(dto.getLinkProduct());
+        product.setCreatedAt(dto.getCreatedAt());
+        return product;
+    }
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/mapper/ProductTypeMapper.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/mapper/ProductTypeMapper.java
@@ -1,0 +1,27 @@
+package com.ceiba.fashtoll.mapper;
+
+import com.ceiba.fashtoll.dto.ProductTypeDTO;
+import com.ceiba.fashtoll.entity.ProductType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProductTypeMapper {
+
+    public ProductTypeDTO toDTO(ProductType productType) {
+        if (productType == null) return null;
+        ProductTypeDTO dto = new ProductTypeDTO();
+        dto.setId(productType.getId());
+        dto.setName(productType.getName());
+        dto.setCategory(productType.getCategory());
+        return dto;
+    }
+
+    public ProductType toEntity(ProductTypeDTO dto) {
+        if (dto == null) return null;
+        ProductType productType = new ProductType();
+        productType.setId(dto.getId());
+        productType.setName(dto.getName());
+        productType.setCategory(dto.getCategory());
+        return productType;
+    }
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/mapper/UserMapper.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/mapper/UserMapper.java
@@ -1,0 +1,33 @@
+package com.ceiba.fashtoll.mapper;
+
+import com.ceiba.fashtoll.dto.UserDTO;
+import com.ceiba.fashtoll.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UserMapper {
+
+    public UserDTO toDTO(User user) {
+        if (user == null) return null;
+        UserDTO dto = new UserDTO();
+        dto.setId(user.getId());
+        dto.setEmail(user.getEmail());
+        dto.setPassword(user.getPassword());
+        dto.setRole(user.getRole());
+        dto.setCreatedAt(user.getCreatedAt());
+        dto.setIsActive(user.getIsActive());
+        return dto;
+    }
+
+    public User toEntity(UserDTO dto) {
+        if (dto == null) return null;
+        User user = new User();
+        user.setId(dto.getId());
+        user.setEmail(dto.getEmail());
+        user.setPassword(dto.getPassword());
+        user.setRole(dto.getRole());
+        user.setCreatedAt(dto.getCreatedAt());
+        user.setIsActive(dto.getIsActive());
+        return user;
+    }
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/repository/ProductRepository.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/repository/ProductRepository.java
@@ -1,9 +1,20 @@
 package com.ceiba.fashtoll.repository;
 
+import com.ceiba.fashtoll.entity.Brand;
 import com.ceiba.fashtoll.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
+
+    List<Product> findByBrand(Brand brand);
+
+    List<Product> findByAvailableTrue();
+
+    List<Product> findByAvailableFalse();
+
+    List<Product> findByBrandId(Long brandId);
 }

--- a/backend/src/main/java/com/ceiba/fashtoll/repository/ProductTypeRepository.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/repository/ProductTypeRepository.java
@@ -1,0 +1,9 @@
+package com.ceiba.fashtoll.repository;
+
+import com.ceiba.fashtoll.entity.ProductType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProductTypeRepository extends JpaRepository<ProductType, Long> {
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/repository/UserRepository.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.ceiba.fashtoll.repository;
+
+import com.ceiba.fashtoll.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/service/BrandService.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/service/BrandService.java
@@ -1,53 +1,78 @@
 package com.ceiba.fashtoll.service;
 
+import com.ceiba.fashtoll.dto.BrandDTO;
 import com.ceiba.fashtoll.entity.Brand;
+import com.ceiba.fashtoll.entity.User;
+import com.ceiba.fashtoll.mapper.BrandMapper;
 import com.ceiba.fashtoll.repository.BrandRepository;
+import com.ceiba.fashtoll.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class BrandService {
 
     private final BrandRepository brandRepository;
+    private final UserRepository userRepository;
+    private final BrandMapper brandMapper;
 
     @Autowired
-    public BrandService(BrandRepository brandRepository) {
+    public BrandService(BrandRepository brandRepository, UserRepository userRepository, BrandMapper brandMapper) {
         this.brandRepository = brandRepository;
+        this.userRepository = userRepository;
+        this.brandMapper = brandMapper;
     }
 
-    public List<Brand> getAllBrands() {
-        return brandRepository.findAll();
+    public List<BrandDTO> getAllBrands() {
+        return brandRepository.findAll().stream()
+                .map(brandMapper::toDTO)
+                .collect(Collectors.toList());
     }
 
-    public Brand getBrandById(Long id) {
-        return brandRepository.findById(id)
+    public BrandDTO getBrandById(Long id) {
+        Brand brand = brandRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Marca no encontrada: " + id));
+        return brandMapper.toDTO(brand);
     }
 
-    public Brand createBrand(Brand brand) {
+    public BrandDTO createBrand(BrandDTO brandDTO) {
+        Brand brand = brandMapper.toEntity(brandDTO);
         if (brand.getFollowers() == null) brand.setFollowers(0);
         if (brand.getRating() == null) brand.setRating(0.0);
         if (brand.getIsVerified() == null) brand.setIsVerified(false);
-        return brandRepository.save(brand);
+        if (brandDTO.getUserId() != null) {
+            User user = userRepository.findById(brandDTO.getUserId())
+                    .orElseThrow(() -> new RuntimeException("Usuario no encontrado: " + brandDTO.getUserId()));
+            brand.setUser(user);
+        }
+        Brand savedBrand = brandRepository.save(brand);
+        return brandMapper.toDTO(savedBrand);
     }
 
-    public Brand updateBrand(Long id, Brand updatedBrand) {
-        Brand brand = getBrandById(id);
-        brand.setName(updatedBrand.getName());
-        brand.setEmail(updatedBrand.getEmail());
-        brand.setPassword(updatedBrand.getPassword());
-        brand.setPictureUrl(updatedBrand.getPictureUrl());
-        brand.setLinkOfficial(updatedBrand.getLinkOfficial());
-        brand.setFollowers(updatedBrand.getFollowers());
-        brand.setRating(updatedBrand.getRating());
-        brand.setIsVerified(updatedBrand.getIsVerified());
-        return brandRepository.save(brand);
+    public BrandDTO updateBrand(Long id, BrandDTO updatedBrandDTO) {
+        Brand brand = brandRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Marca no encontrada: " + id));
+        brand.setName(updatedBrandDTO.getName());
+        brand.setPictureUrl(updatedBrandDTO.getPictureUrl());
+        brand.setLinkOfficial(updatedBrandDTO.getLinkOfficial());
+        brand.setFollowers(updatedBrandDTO.getFollowers());
+        brand.setRating(updatedBrandDTO.getRating());
+        brand.setIsVerified(updatedBrandDTO.getIsVerified());
+        if (updatedBrandDTO.getUserId() != null) {
+            User user = userRepository.findById(updatedBrandDTO.getUserId())
+                    .orElseThrow(() -> new RuntimeException("Usuario no encontrado: " + updatedBrandDTO.getUserId()));
+            brand.setUser(user);
+        }
+        Brand savedBrand = brandRepository.save(brand);
+        return brandMapper.toDTO(savedBrand);
     }
 
     public void deleteBrand(Long id) {
-        Brand brand = getBrandById(id);
+        Brand brand = brandRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Marca no encontrada: " + id));
         brandRepository.delete(brand);
     }
 }

--- a/backend/src/main/java/com/ceiba/fashtoll/service/ClientService.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/service/ClientService.java
@@ -1,45 +1,70 @@
 package com.ceiba.fashtoll.service;
 
+import com.ceiba.fashtoll.dto.ClientDTO;
 import com.ceiba.fashtoll.entity.Client;
+import com.ceiba.fashtoll.entity.User;
+import com.ceiba.fashtoll.mapper.ClientMapper;
 import com.ceiba.fashtoll.repository.ClientRepository;
+import com.ceiba.fashtoll.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ClientService {
 
     private final ClientRepository clientRepository;
+    private final UserRepository userRepository;
+    private final ClientMapper clientMapper;
 
     @Autowired
-    public ClientService(ClientRepository clientRepository) {
+    public ClientService(ClientRepository clientRepository, UserRepository userRepository, ClientMapper clientMapper) {
         this.clientRepository = clientRepository;
+        this.userRepository = userRepository;
+        this.clientMapper = clientMapper;
     }
 
-    public List<Client> getAllClients() {
-        return clientRepository.findAll();
+    public List<ClientDTO> getAllClients() {
+        return clientRepository.findAll().stream()
+                .map(clientMapper::toDTO)
+                .collect(Collectors.toList());
     }
 
-    public Client getClientById(Long id) {
-        return clientRepository.findById(id)
+    public ClientDTO getClientById(Long id) {
+        Client client = clientRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Cliente no encontrado: " + id));
+        return clientMapper.toDTO(client);
     }
 
-    public Client createClient(Client client) {
-        return clientRepository.save(client);
+    public ClientDTO createClient(ClientDTO clientDTO) {
+        Client client = clientMapper.toEntity(clientDTO);
+        if (clientDTO.getUserId() != null) {
+            User user = userRepository.findById(clientDTO.getUserId())
+                    .orElseThrow(() -> new RuntimeException("Usuario no encontrado: " + clientDTO.getUserId()));
+            client.setUser(user);
+        }
+        Client savedClient = clientRepository.save(client);
+        return clientMapper.toDTO(savedClient);
     }
 
-    public Client updateClient(Long id, Client updatedClient) {
-        Client client = getClientById(id);
-        client.setName(updatedClient.getName());
-        client.setEmail(updatedClient.getEmail());
-        client.setPassword(updatedClient.getPassword());
-        return clientRepository.save(client);
+    public ClientDTO updateClient(Long id, ClientDTO updatedClientDTO) {
+        Client client = clientRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Cliente no encontrado: " + id));
+        client.setName(updatedClientDTO.getName());
+        if (updatedClientDTO.getUserId() != null) {
+            User user = userRepository.findById(updatedClientDTO.getUserId())
+                    .orElseThrow(() -> new RuntimeException("Usuario no encontrado: " + updatedClientDTO.getUserId()));
+            client.setUser(user);
+        }
+        Client savedClient = clientRepository.save(client);
+        return clientMapper.toDTO(savedClient);
     }
 
     public void deleteClient(Long id) {
-        Client client = getClientById(id);
+        Client client = clientRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Cliente no encontrado: " + id));
         clientRepository.delete(client);
     }
 }

--- a/backend/src/main/java/com/ceiba/fashtoll/service/ProductService.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/service/ProductService.java
@@ -1,10 +1,94 @@
 package com.ceiba.fashtoll.service;
 
+import com.ceiba.fashtoll.dto.ProductDTO;
+import com.ceiba.fashtoll.entity.Brand;
+import com.ceiba.fashtoll.entity.Product;
+import com.ceiba.fashtoll.entity.ProductType;
+import com.ceiba.fashtoll.mapper.ProductMapper;
+import com.ceiba.fashtoll.repository.BrandRepository;
+import com.ceiba.fashtoll.repository.ProductRepository;
+import com.ceiba.fashtoll.repository.ProductTypeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class ProductService {
 
+    private final ProductRepository productRepository;
+    private final BrandRepository brandRepository;
+    private final ProductTypeRepository productTypeRepository;
+    private final ProductMapper productMapper;
 
+    @Autowired
+    public ProductService(ProductRepository productRepository, BrandRepository brandRepository, ProductTypeRepository productTypeRepository, ProductMapper productMapper) {
+        this.productRepository = productRepository;
+        this.brandRepository = brandRepository;
+        this.productTypeRepository = productTypeRepository;
+        this.productMapper = productMapper;
+    }
 
+    public List<ProductDTO> getAllProducts() {
+        return productRepository.findAll().stream()
+                .map(productMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public ProductDTO getProductById(Long id) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Producto no encontrado: " + id));
+        return productMapper.toDTO(product);
+    }
+
+    public ProductDTO createProduct(ProductDTO productDTO) {
+        Product product = productMapper.toEntity(productDTO);
+        if (productDTO.getBrandId() != null) {
+            Brand brand = brandRepository.findById(productDTO.getBrandId())
+                    .orElseThrow(() -> new RuntimeException("Marca no encontrada: " + productDTO.getBrandId()));
+            product.setBrand(brand);
+        }
+        if (productDTO.getProductTypeId() != null) {
+            ProductType productType = productTypeRepository.findById(productDTO.getProductTypeId())
+                    .orElseThrow(() -> new RuntimeException("Tipo de producto no encontrado: " + productDTO.getProductTypeId()));
+            product.setProductType(productType);
+        }
+        if (product.getAvailable() == null) product.setAvailable(true);
+        if (product.getRating() == null) product.setRating(0.0);
+        Product savedProduct = productRepository.save(product);
+        return productMapper.toDTO(savedProduct);
+    }
+
+    public ProductDTO updateProduct(Long id, ProductDTO updatedProductDTO) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Producto no encontrado: " + id));
+        product.setName(updatedProductDTO.getName());
+        product.setDescription(updatedProductDTO.getDescription());
+        product.setPrice(updatedProductDTO.getPrice());
+        product.setGeneralFit(updatedProductDTO.getGeneralFit());
+        product.setGender(updatedProductDTO.getGender());
+        product.setColor(updatedProductDTO.getColor());
+        product.setAvailable(updatedProductDTO.getAvailable());
+        product.setRating(updatedProductDTO.getRating());
+        product.setLinkProduct(updatedProductDTO.getLinkProduct());
+        if (updatedProductDTO.getBrandId() != null) {
+            Brand brand = brandRepository.findById(updatedProductDTO.getBrandId())
+                    .orElseThrow(() -> new RuntimeException("Marca no encontrada: " + updatedProductDTO.getBrandId()));
+            product.setBrand(brand);
+        }
+        if (updatedProductDTO.getProductTypeId() != null) {
+            ProductType productType = productTypeRepository.findById(updatedProductDTO.getProductTypeId())
+                    .orElseThrow(() -> new RuntimeException("Tipo de producto no encontrado: " + updatedProductDTO.getProductTypeId()));
+            product.setProductType(productType);
+        }
+        Product savedProduct = productRepository.save(product);
+        return productMapper.toDTO(savedProduct);
+    }
+
+    public void deleteProduct(Long id) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Producto no encontrado: " + id));
+        productRepository.delete(product);
+    }
 }

--- a/backend/src/main/java/com/ceiba/fashtoll/service/ProductTypeService.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/service/ProductTypeService.java
@@ -1,0 +1,57 @@
+package com.ceiba.fashtoll.service;
+
+import com.ceiba.fashtoll.dto.ProductTypeDTO;
+import com.ceiba.fashtoll.entity.ProductType;
+import com.ceiba.fashtoll.mapper.ProductTypeMapper;
+import com.ceiba.fashtoll.repository.ProductTypeRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class ProductTypeService {
+
+    private final ProductTypeRepository productTypeRepository;
+    private final ProductTypeMapper productTypeMapper;
+
+    @Autowired
+    public ProductTypeService(ProductTypeRepository productTypeRepository, ProductTypeMapper productTypeMapper) {
+        this.productTypeRepository = productTypeRepository;
+        this.productTypeMapper = productTypeMapper;
+    }
+
+    public List<ProductTypeDTO> getAllProductTypes() {
+        return productTypeRepository.findAll().stream()
+                .map(productTypeMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public ProductTypeDTO getProductTypeById(Long id) {
+        ProductType productType = productTypeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tipo de producto no encontrado: " + id));
+        return productTypeMapper.toDTO(productType);
+    }
+
+    public ProductTypeDTO createProductType(ProductTypeDTO productTypeDTO) {
+        ProductType productType = productTypeMapper.toEntity(productTypeDTO);
+        ProductType savedProductType = productTypeRepository.save(productType);
+        return productTypeMapper.toDTO(savedProductType);
+    }
+
+    public ProductTypeDTO updateProductType(Long id, ProductTypeDTO updatedProductTypeDTO) {
+        ProductType productType = productTypeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tipo de producto no encontrado: " + id));
+        productType.setName(updatedProductTypeDTO.getName());
+        productType.setCategory(updatedProductTypeDTO.getCategory());
+        ProductType savedProductType = productTypeRepository.save(productType);
+        return productTypeMapper.toDTO(savedProductType);
+    }
+
+    public void deleteProductType(Long id) {
+        ProductType productType = productTypeRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Tipo de producto no encontrado: " + id));
+        productTypeRepository.delete(productType);
+    }
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/service/UserService.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/service/UserService.java
@@ -1,0 +1,60 @@
+package com.ceiba.fashtoll.service;
+
+import com.ceiba.fashtoll.dto.UserDTO;
+import com.ceiba.fashtoll.entity.User;
+import com.ceiba.fashtoll.mapper.UserMapper;
+import com.ceiba.fashtoll.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final UserMapper userMapper;
+
+    @Autowired
+    public UserService(UserRepository userRepository, UserMapper userMapper) {
+        this.userRepository = userRepository;
+        this.userMapper = userMapper;
+    }
+
+    public List<UserDTO> getAllUsers() {
+        return userRepository.findAll().stream()
+                .map(userMapper::toDTO)
+                .collect(Collectors.toList());
+    }
+
+    public UserDTO getUserById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado: " + id));
+        return userMapper.toDTO(user);
+    }
+
+    public UserDTO createUser(UserDTO userDTO) {
+        User user = userMapper.toEntity(userDTO);
+        if (user.getIsActive() == null) user.setIsActive(true);
+        User savedUser = userRepository.save(user);
+        return userMapper.toDTO(savedUser);
+    }
+
+    public UserDTO updateUser(Long id, UserDTO updatedUserDTO) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado: " + id));
+        user.setEmail(updatedUserDTO.getEmail());
+        user.setRole(updatedUserDTO.getRole());
+        user.setCreatedAt(updatedUserDTO.getCreatedAt());
+        user.setIsActive(updatedUserDTO.getIsActive());
+        User savedUser = userRepository.save(user);
+        return userMapper.toDTO(savedUser);
+    }
+
+    public void deleteUser(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado: " + id));
+        userRepository.delete(user);
+    }
+}


### PR DESCRIPTION
- Se unificaron las entidades Cliente y Marca en una entidad User que gestiona las credenciales de acceso. 
- Se implementaron las capas de Entidad, Repositorio, DTO, Mapper, Servicio y Controlador para todas las entidades principales desarrolladas hasta ahora (Usuario, Cliente, Marca, Producto y Tipo Producto)
- Se desarrolló un CRUD simple para las entidades Usuario, Cliente, Marca, Producto y Tipo Producto, haciendo uso del patrón DTO y probando la funcionalidad con Postman.
- A continuación, algunos pantallazos de evidencia de las pruebas hechas con Postman.

### Creación de Usuarios de tipo Cliente y Marca
<img width="853" height="644" alt="image" src="https://github.com/user-attachments/assets/ac843d1a-0aa2-4c5f-97b8-8cb4ed7a39dc" />

### Creación de Cliente
<img width="845" height="464" alt="image" src="https://github.com/user-attachments/assets/714a45d7-c9eb-40ba-9b09-fa1b74bfb6e6" />

### Creación de Marca
<img width="844" height="574" alt="image" src="https://github.com/user-attachments/assets/a7e2355d-468c-4d4b-a94f-97ec9d1e35b2" />

### Creación de Tipos de Producto
<img width="836" height="617" alt="image" src="https://github.com/user-attachments/assets/699d64d7-a67d-4a15-a2f3-4d920a6a87ea" />

### Creación de Productos
<img width="813" height="868" alt="image" src="https://github.com/user-attachments/assets/b527ef44-b1da-455e-ac77-64aa2d8d9675" />
