### PR TITLE
Implementar inicio de sesión y gestión de perfil de clientes y marcas (PR a Main)

### DIFF
--- a/backend/src/main/java/com/ceiba/fashtoll/brand/controller/BrandController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/brand/controller/BrandController.java
@@ -1,10 +1,18 @@
 package com.ceiba.fashtoll.brand.controller;
 
 import com.ceiba.fashtoll.brand.dto.BrandDTO;
+import com.ceiba.fashtoll.brand.dto.BrandProfileDTO;
 import com.ceiba.fashtoll.brand.service.BrandService;
+import com.ceiba.fashtoll.product.dto.ProductDTO;
+import com.ceiba.fashtoll.product.service.ProductService;
+import com.ceiba.fashtoll.user.dto.PasswordChangeRequestDTO;
+import com.ceiba.fashtoll.user.entity.User;
+import com.ceiba.fashtoll.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,34 +22,81 @@ import java.util.List;
 public class BrandController {
 
     private final BrandService brandService;
+    private final UserService userService;
+    private final ProductService productService;
 
     @Autowired
-    public BrandController(BrandService brandService) {
+    public BrandController(BrandService brandService, UserService userService, ProductService productService) {
         this.brandService = brandService;
+        this.userService = userService;
+        this.productService = productService;
     }
 
+    @GetMapping("/profile")
+    public BrandProfileDTO getProfile(Authentication authentication) {
+        User user = (User) authentication.getPrincipal();
+        return brandService.getProfile(user.getId());
+    }
+
+    @PutMapping("/profile")
+    public BrandProfileDTO updateProfile(Authentication authentication, @RequestBody BrandProfileDTO profileDTO) {
+        User user = (User) authentication.getPrincipal();
+        return brandService.updateProfile(user.getId(), profileDTO);
+    }
+
+    @PutMapping("/password")
+    public ResponseEntity<Void> changePassword(Authentication authentication, @RequestBody PasswordChangeRequestDTO request) {
+        User user = (User) authentication.getPrincipal();
+        userService.changePassword(user.getId(), request);
+        return ResponseEntity.noContent().build();
+    }
+
+//    @GetMapping("/my-products")
+//    public List<ProductDTO> getMyProducts(Authentication authentication) {
+//        User user = (User) authentication.getPrincipal();
+//        return productService.getProductsByBrand(user.getId());
+//    }
+//
+//    @PutMapping("/my-products/{id}")
+//    public ProductDTO updateMyProduct(Authentication authentication, @PathVariable Long id, @RequestBody ProductDTO productDTO) {
+//        User user = (User) authentication.getPrincipal();
+//        return productService.updateBrandProduct(user.getId(), id, productDTO);
+//    }
+//
+//    @DeleteMapping("/my-products/{id}")
+//    public ResponseEntity<Void> deleteMyProduct(Authentication authentication, @PathVariable Long id) {
+//        User user = (User) authentication.getPrincipal();
+//        productService.deleteBrandProduct(user.getId(), id);
+//        return ResponseEntity.noContent().build();
+//    }
+
     @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public List<BrandDTO> getAllBrands() {
         return brandService.getAllBrands();
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public BrandDTO getBrandById(@PathVariable Long id) {
         return brandService.getBrandById(id);
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<BrandDTO> createBrand(@RequestBody BrandDTO brandDTO) {
         BrandDTO newBrand = brandService.createBrand(brandDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(newBrand);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public BrandDTO updateBrand(@PathVariable Long id, @RequestBody BrandDTO updatedBrandDTO) {
         return brandService.updateBrand(id, updatedBrandDTO);
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteBrand(@PathVariable Long id) {
         brandService.deleteBrand(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/ceiba/fashtoll/brand/dto/BrandProfileDTO.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/brand/dto/BrandProfileDTO.java
@@ -1,0 +1,18 @@
+package com.ceiba.fashtoll.brand.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BrandProfileDTO {
+    private String name;
+    private String email;
+    private String pictureUrl;
+    private String linkOfficial;
+    private Integer followers;
+    private Double rating;
+    private Boolean isVerified;
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/brand/service/BrandService.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/brand/service/BrandService.java
@@ -1,6 +1,7 @@
 package com.ceiba.fashtoll.brand.service;
 
 import com.ceiba.fashtoll.brand.dto.BrandDTO;
+import com.ceiba.fashtoll.brand.dto.BrandProfileDTO;
 import com.ceiba.fashtoll.brand.entity.Brand;
 import com.ceiba.fashtoll.user.entity.User;
 import com.ceiba.fashtoll.brand.mapper.BrandMapper;
@@ -74,5 +75,36 @@ public class BrandService {
         Brand brand = brandRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Marca no encontrada: " + id));
         brandRepository.delete(brand);
+    }
+
+    public BrandProfileDTO getProfile(Long userId) {
+        Brand brand = brandRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Marca no encontrada"));
+        return new BrandProfileDTO(
+                brand.getName(),
+                brand.getUser().getEmail(),
+                brand.getPictureUrl(),
+                brand.getLinkOfficial(),
+                brand.getFollowers(),
+                brand.getRating(),
+                brand.getIsVerified()
+        );
+    }
+
+    public BrandProfileDTO updateProfile(Long userId, BrandProfileDTO profileDTO) {
+        Brand brand = brandRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Marca no encontrada"));
+        brand.setName(profileDTO.getName());
+        brand.setPictureUrl(profileDTO.getPictureUrl());
+        brand.setLinkOfficial(profileDTO.getLinkOfficial());
+        brandRepository.save(brand);
+        return getProfile(userId);
+    }
+
+    public void verifyBrand(Long id, boolean verified) {
+        Brand brand = brandRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Marca no encontrada"));
+        brand.setIsVerified(verified);
+        brandRepository.save(brand);
     }
 }

--- a/backend/src/main/java/com/ceiba/fashtoll/client/controller/ClientController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/client/controller/ClientController.java
@@ -1,10 +1,16 @@
 package com.ceiba.fashtoll.client.controller;
 
 import com.ceiba.fashtoll.client.dto.ClientDTO;
+import com.ceiba.fashtoll.client.dto.ClientProfileDTO;
 import com.ceiba.fashtoll.client.service.ClientService;
+import com.ceiba.fashtoll.user.dto.PasswordChangeRequestDTO;
+import com.ceiba.fashtoll.user.entity.User;
+import com.ceiba.fashtoll.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -14,34 +20,60 @@ import java.util.List;
 public class ClientController {
 
     private final ClientService clientService;
+    private final UserService userService;
 
     @Autowired
-    public ClientController(ClientService clientService) {
+    public ClientController(ClientService clientService, UserService userService) {
         this.clientService = clientService;
+        this.userService = userService;
+    }
+
+    @GetMapping("/profile")
+    public ClientProfileDTO getProfile(Authentication authentication) {
+        User user = (User) authentication.getPrincipal();
+        return clientService.getProfile(user.getId());
+    }
+
+    @PutMapping("/profile")
+    public ClientProfileDTO updateProfile(Authentication authentication, @RequestBody ClientProfileDTO profileDTO) {
+        User user = (User) authentication.getPrincipal();
+        return clientService.updateProfile(user.getId(), profileDTO);
+    }
+
+    @PutMapping("/password")
+    public ResponseEntity<Void> changePassword(Authentication authentication, @RequestBody PasswordChangeRequestDTO request) {
+        User user = (User) authentication.getPrincipal();
+        userService.changePassword(user.getId(), request);
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public List<ClientDTO> getAllClients() {
         return clientService.getAllClients();
     }
 
     @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ClientDTO getClientById(@PathVariable Long id) {
         return clientService.getClientById(id);
     }
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ClientDTO> createClient(@RequestBody ClientDTO clientDTO) {
         ClientDTO newClient = clientService.createClient(clientDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(newClient);
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ClientDTO updateClient(@PathVariable Long id, @RequestBody ClientDTO updatedClientDTO) {
         return clientService.updateClient(id, updatedClientDTO);
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteClient(@PathVariable Long id) {
         clientService.deleteClient(id);
         return ResponseEntity.noContent().build();

--- a/backend/src/main/java/com/ceiba/fashtoll/client/dto/ClientProfileDTO.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/client/dto/ClientProfileDTO.java
@@ -1,0 +1,13 @@
+package com.ceiba.fashtoll.client.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClientProfileDTO {
+    private String name;
+    private String email;
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/client/service/ClientService.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/client/service/ClientService.java
@@ -1,6 +1,7 @@
 package com.ceiba.fashtoll.client.service;
 
 import com.ceiba.fashtoll.client.dto.ClientDTO;
+import com.ceiba.fashtoll.client.dto.ClientProfileDTO;
 import com.ceiba.fashtoll.client.entity.Client;
 import com.ceiba.fashtoll.user.entity.User;
 import com.ceiba.fashtoll.client.mapper.ClientMapper;
@@ -66,5 +67,19 @@ public class ClientService {
         Client client = clientRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Cliente no encontrado: " + id));
         clientRepository.delete(client);
+    }
+
+    public ClientProfileDTO getProfile(Long userId) {
+        Client client = clientRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
+        return new ClientProfileDTO(client.getName(), client.getUser().getEmail());
+    }
+
+    public ClientProfileDTO updateProfile(Long userId, ClientProfileDTO profileDTO) {
+        Client client = clientRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Cliente no encontrado"));
+        client.setName(profileDTO.getName());
+        clientRepository.save(client);
+        return new ClientProfileDTO(client.getName(), client.getUser().getEmail());
     }
 }

--- a/backend/src/main/java/com/ceiba/fashtoll/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/config/SecurityConfig.java
@@ -39,11 +39,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/users/**").permitAll()
-                        .requestMatchers("/api/clients/**").permitAll()
-                        .requestMatchers("/api/brands/**").permitAll()
-                        .requestMatchers("/api/products/**").permitAll()
-                        .requestMatchers("/api/product-types/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )
                 .sessionManagement(session -> session

--- a/backend/src/main/java/com/ceiba/fashtoll/product/controller/ProductController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/product/controller/ProductController.java
@@ -5,6 +5,7 @@ import com.ceiba.fashtoll.product.service.ProductService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,17 +31,20 @@ public class ProductController {
         return productService.getProductById(id);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     public ResponseEntity<ProductDTO> createProduct(@RequestBody ProductDTO productDTO) {
         ProductDTO newProduct = productService.createProduct(productDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(newProduct);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{id}")
     public ProductDTO updateProduct(@PathVariable Long id, @RequestBody ProductDTO updatedProductDTO) {
         return productService.updateProduct(id, updatedProductDTO);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {
         productService.deleteProduct(id);

--- a/backend/src/main/java/com/ceiba/fashtoll/product/controller/ProductTypeController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/product/controller/ProductTypeController.java
@@ -5,6 +5,7 @@ import com.ceiba.fashtoll.product.service.ProductTypeService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -30,17 +31,20 @@ public class ProductTypeController {
         return productTypeService.getProductTypeById(id);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PostMapping
     public ResponseEntity<ProductTypeDTO> createProductType(@RequestBody ProductTypeDTO productTypeDTO) {
         ProductTypeDTO newProductType = productTypeService.createProductType(productTypeDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(newProductType);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @PutMapping("/{id}")
     public ProductTypeDTO updateProductType(@PathVariable Long id, @RequestBody ProductTypeDTO updatedProductTypeDTO) {
         return productTypeService.updateProductType(id, updatedProductTypeDTO);
     }
 
+    @PreAuthorize("hasRole('ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteProductType(@PathVariable Long id) {
         productTypeService.deleteProductType(id);

--- a/backend/src/main/java/com/ceiba/fashtoll/user/controller/AdminController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/user/controller/AdminController.java
@@ -1,0 +1,30 @@
+package com.ceiba.fashtoll.user.controller;
+
+import com.ceiba.fashtoll.brand.service.BrandService;
+import com.ceiba.fashtoll.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin")
+@PreAuthorize("hasRole('ADMIN')")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final UserService userService;
+    private final BrandService brandService;
+
+    @PutMapping("/users/{id}/status")
+    public ResponseEntity<Void> setUserStatus(@PathVariable Long id, @RequestParam boolean active) {
+        userService.setUserActiveStatus(id, active);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PutMapping("/brands/{id}/verify")
+    public ResponseEntity<Void> verifyBrand(@PathVariable Long id, @RequestParam boolean verified) {
+        brandService.verifyBrand(id, verified);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/user/controller/UserController.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/user/controller/UserController.java
@@ -5,12 +5,14 @@ import com.ceiba.fashtoll.user.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
+@PreAuthorize("hasRole('ADMIN')")
 public class UserController {
 
     private final UserService userService;

--- a/backend/src/main/java/com/ceiba/fashtoll/user/dto/PasswordChangeRequestDTO.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/user/dto/PasswordChangeRequestDTO.java
@@ -1,0 +1,13 @@
+package com.ceiba.fashtoll.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordChangeRequestDTO {
+    private String currentPassword;
+    private String newPassword;
+}

--- a/backend/src/main/java/com/ceiba/fashtoll/user/service/UserService.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/user/service/UserService.java
@@ -1,11 +1,14 @@
 package com.ceiba.fashtoll.user.service;
 
+import com.ceiba.fashtoll.user.dto.PasswordChangeRequestDTO;
 import com.ceiba.fashtoll.user.dto.UserDTO;
 import com.ceiba.fashtoll.user.entity.User;
 import com.ceiba.fashtoll.user.mapper.UserMapper;
 import com.ceiba.fashtoll.user.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,11 +18,13 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final UserMapper userMapper;
+    private final PasswordEncoder passwordEncoder;
 
     @Autowired
-    public UserService(UserRepository userRepository, UserMapper userMapper) {
+    public UserService(UserRepository userRepository, UserMapper userMapper, PasswordEncoder passwordEncoder) {
         this.userRepository = userRepository;
         this.userMapper = userMapper;
+        this.passwordEncoder = passwordEncoder;
     }
 
     public List<UserDTO> getAllUsers() {
@@ -56,5 +61,25 @@ public class UserService {
         User user = userRepository.findById(id)
                 .orElseThrow(() -> new RuntimeException("Usuario no encontrado: " + id));
         userRepository.delete(user);
+    }
+
+    @Transactional
+    public void changePassword(Long userId, PasswordChangeRequestDTO request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPassword())) {
+            throw new RuntimeException("La contraseña actual es incorrecta");
+        }
+
+        user.setPassword(passwordEncoder.encode(request.getNewPassword()));
+        userRepository.save(user);
+    }
+
+    public void setUserActiveStatus(Long id, boolean active) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+        user.setIsActive(active);
+        userRepository.save(user);
     }
 }


### PR DESCRIPTION
## Features implementadas

### Rol de Administrador
- Crear el controlador de Administradores con un endpoint para activar o desactivar la cuenta de un usuario (`setUserStatus()`) y verificar o desverificar una marca (`verifyBrand()`).
- Crear los respectivos métodos en los servicios de usuario y marca
- Limitar el acceso a los endpoints CRUD (create, update, delete) de ProductType para que solo sean accesibles por un administrador (`@PreAuthorize("hasRole('ADMIN')")`)
- Limitar el acceso a los endpoints CRUD (create, update, delete) de Product para que solo sean accesibles por un administrador (`@PreAuthorize("hasRole('ADMIN')")`)
- Limitar el acceso a los endpoints CRUD (todos) de User para que solo sean accesibles por un administrador (`@PreAuthorize("hasRole('ADMIN')")`)
- Limitar el acceso a los endpoints CRUD (todos) de Brand para que solo sean accesibles por un administrador (`@PreAuthorize("hasRole('ADMIN')")`)
- Limitar el acceso a los endpoints CRUD (todos) de Client para que solo sean accesibles por un administrador (`@PreAuthorize("hasRole('ADMIN')")`)
- Modificar el método `securityFilterChain()` en SecurityConfig para respetar el acceso exclusivo a endpoints CRUD para administradores y que todos los demás endpoints requieran autenticación

### Gestión de perfil de Marca
- Crear el DTO BrandProfileDTO para mostrar la información de perfil de una marca
- Crear el DTO PasswordChangeRequestDTO para solicitar la contraseña actual y la nueva contraseña en el cambio de contraseña de un usuario
- Agregar métodos en el servicio de marca para consultar y actualizar información del perfil de una marca
- Agregar método en el servicio de un usuario para cambiar su contraseña
- Agregar nuevos endpoints en el controlador de marcas para consultar y actualizar su información de perfil de una marca autenticada, así como actualizar su contraseña

### Gestión de perfil de Cliente
- Crear el DTO ClientProfileDTO para mostrar la información de perfil de un cliente
- Agregar métodos en el servicio de cliente para consultar y actualizar información del perfil de una marca
- Agregar nuevos endpoints en el controlador de clientes para consultar y actualizar su información de perfil de una marca autenticada, así como actualizar su contraseña

---

## Testeo de registro e inicio de sesión de Administradores, Marcas y Clientes en Postman

### Administradores
Un admin se puede registrar desde http://localhost:8080/api/auth/register como cualquier otro usuario.
<img width="848" height="326" alt="image" src="https://github.com/user-attachments/assets/167e0a43-84bb-4ad4-93c8-31d05a57c684" />

Un admin inicia sesión desde http://localhost:8080/api/auth/login como cualquier otro usuario. Se genera el token para la autenticación en sus endpoints autorizados.
<img width="837" height="537" alt="image" src="https://github.com/user-attachments/assets/9c5470e9-8ee8-4d09-8a6a-593813bea987" />

Un admin autenticado puede activar o desactivar la cuenta de un usuario desde http://localhost:8080/api/admin/users/{id}/status?active={active}, colocando el id y el nuevo estado de la cuenta después del símbolo "=", por ejemplo: /api/admin/users/1/status?active=false para desactivar una cuenta activa con el id 1. En Postman es necesario colocar el token JWT de autenticación en la pestaña "Authorization", seleccionando el tipo de autenticación "Bearer Token".
<img width="851" height="346" alt="image" src="https://github.com/user-attachments/assets/9896a67c-9019-4c26-a9da-d242f32f1f21" />

Un admin autenticado puede verificar o desverificar una marca desde http://localhost:8080/api/admin/brands/{id}/verify?verified={verified}, colocando el id y el nuevo estado de verificación de la marca después del símbolo "=", por ejemplo: /api/admin/brands/3/verify?verified=true para verificar una marca con id 3. En Postman es necesario colocar el token JWT de autenticación en la pestaña "Authorization", seleccionando el tipo de autenticación "Bearer Token".
<img width="848" height="366" alt="image" src="https://github.com/user-attachments/assets/2bd60687-ded0-4421-a0c6-90021662c725" />

Ahora, todas las operaciones CRUD de Usuarios, Clientes, Marcas, Productos y Tipo Productos requieren la autenticación de un usuario de tipo admin (colocando el token JWT en Postman).
<img width="850" height="677" alt="image" src="https://github.com/user-attachments/assets/129e7428-0aff-4c9c-beb5-e7dd976359f7" />

---
### Perfil de Marcas
Una marca se puede registrar desde http://localhost:8080/api/auth/register como cualquier otro usuario, llenando más campos que un cliente.
<img width="851" height="347" alt="image" src="https://github.com/user-attachments/assets/352f9f0d-04c0-433f-97f5-cb4cf0fe56cc" />

Una marca inicia sesión desde http://localhost:8080/api/auth/login como cualquier otro usuario. Se genera el token para la autenticación en sus endpoints autorizados.
<img width="859" height="534" alt="image" src="https://github.com/user-attachments/assets/7aece9d8-27aa-418c-a244-26e3692a68fa" />

Una marca autenticada puede consultar o actualizar (GET o PUT) su información de perfil desde http://localhost:8080/api/brands/profile. La marca necesita estar autenticada con su token JWT.
<img width="848" height="572" alt="image" src="https://github.com/user-attachments/assets/7af35766-2f0d-4639-be80-5d0379bf6d8c" />

Una marca autenticada puede cambiar su contraseña desde http://localhost:8080/api/brands/password, enviando un JSON con la contraseña actual y la nueva contraseña. La marca necesita estar autenticada con su token JWT.
<img width="851" height="366" alt="image" src="https://github.com/user-attachments/assets/16c1363e-88d5-44f7-8fa0-02c8a13cb255" />

---
### Perfil de Clientes
Para un cliente, su registro, inicio de sesión, consulta y actualización de información de perfil, así como su cambio de contraseña funcionan exactamente igual que para una marca, pero con endpoints diferentes para su perfil y cambio de contraseña:
- Consulta y Actualización de perfil: http://localhost:8080/api/clients/profile
- Cambio de contraseña: http://localhost:8080/api/clients/password
---

## Conclusiones y estado actual de la aplicación
Con estos nuevos cambios, los roles de la aplicación están bien definidos, protegiendo endpoints CRUD solo para administradores y permitiendo que un cliente o marca gestione solo su propia información. Spring Security y JWT ha sido correctamente implementados en el sistema y las funcionalidades futuras serán pensadas para seguir esta lógica de roles. En los próximos sprints se implementarán la creación y la gestión de productos de una marca, asegurando que solo tengan acceso a sus propios productos. Esta misma lógica se seguirá para Wishlists de un Cliente y otras entidades futuras.

## Cierre de Issues
- Closes #61 
- Closes #79