### PR TITLE
Implementar OpenAPI y Swagger en la aplicación Spring Boot

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -129,6 +129,11 @@
 			<artifactId>spring-boot-starter-webmvc-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>3.0.1</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/ceiba/fashtoll/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ceiba/fashtoll/config/SecurityConfig.java
@@ -39,6 +39,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
Se agregó la siguiente dependencia al pom.xml:
``` XML
<dependency>
	<groupId>org.springdoc</groupId>
	<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
	<version>3.0.1</version>
</dependency>
```

Esto habilitó inmediatamente y sin configuración adicional dos endpoints:
- http://localhost:8080/swagger-ui/index.html -> Swagger UI para revisión y testeo de endpoints.
- http://localhost:8080/v3/api-docs -> Documentación completa de la API en formato JSON.

Además, se modificó el método `SecurityFilterChain()` en SecurityConfig para permitir el acceso a estos endpoints a cualquier petición, autenticada o no.