### PR TITLE
Intento de corregir errores del pipeline docs.yml

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   generate-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     services:
       postgres:
@@ -30,6 +32,8 @@ jobs:
         env:
           discovery.type: single-node
           xpack.security.enabled: "false"
+          node.store.allow_mmap: "false"
+          ES_JAVA_OPTS: "-Xms512m -Xmx512m"
         ports:
           - 9200:9200
         options: >-


### PR DESCRIPTION
El commit 0bb1d7f076249f9a657451afb7efae6eda1ff776 busca corregir el error que detiene el pipeline `docs.yml` relacionado con el levantamiento de servicio de Elasticsearch.

- Se agregó `node.store.allow_mmap: "false"` a las variables de entorno para evitar el problema de `max virtual memory areas`. También se añadió `ES_JAVA_OPTS: "-Xms512m -Xmx512m"` para reducir el consumo total de RAM que requiere el contenedor de ES que causaba inestabilidades.
- Se añadieron las propiedades `permissions: contents: write` dentro del job `generate-docs` para asegurar que el runner asigne un token con permisos con los que el `git-auto-commit-action` pueda hacer push del archivo .md generado al repositorio.